### PR TITLE
Adjust for Services now being available thru globalThis.Services

### DIFF
--- a/experiments/cachingfix/parent.js
+++ b/experiments/cachingfix/parent.js
@@ -16,8 +16,8 @@ var ex_cachingfix = class extends ExtensionCommon.ExtensionAPI {
       }
     }
     // Clear caches that could prevent upgrades from working properly
-    const { Services } = ChromeUtils.import(
-        "resource://gre/modules/Services.jsm");
+    const Services = globalThis.Services || 
+      ChromeUtils.import("resource://gre/modules/Services.jsm").Services;
     Services.obs.notifyObservers(null, "startupcache-invalidate", null);
   }
   getAPI(context) {

--- a/experiments/customui/parent.js
+++ b/experiments/customui/parent.js
@@ -1,8 +1,8 @@
 var ex_customui = class extends ExtensionCommon.ExtensionAPI {
   getAPI(context) {
     const Cc = Components.classes;
-    const { Services } = ChromeUtils.import(
-        "resource://gre/modules/Services.jsm");
+    const Services = globalThis.Services || 
+      ChromeUtils.import("resource://gre/modules/Services.jsm").Services;
     const { ExtensionParent } = ChromeUtils.import(
         "resource://gre/modules/ExtensionParent.jsm");
     const { setTimeout } = ChromeUtils.import(


### PR DESCRIPTION
There is no difference at the moment, but support could be dropped anytime:
https://searchfox.org/mozilla-central/rev/346a76bee7dc0e60f8f2ae9690785e818bd05cec/toolkit/modules/Services.jsm#5